### PR TITLE
Terminal: command execution sandbox

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/beaker-app-stdlib"]
+	path = vendor/beaker-app-stdlib
+	url = https://github.com/beakerbrowser/beaker-app-stdlib

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <sidebar-app></sidebar-app>
     <div id="monaco-editor"></div>
     <div id="monaco-diff-editor"></div>
+    <iframe src="/sandbox" sandbox="allow-scripts" hidden></iframe>
     <script src="beaker://assets/vs/loader.js"></script>
     <script src="/vendor/dat-serve-resolve-path.js"></script>
     <script src="/vendor/beaker-permissions.js"></script>

--- a/js/lib/iframe-dom-transport.js
+++ b/js/lib/iframe-dom-transport.js
@@ -1,0 +1,49 @@
+const FORBIDDEN_NODES = ['iframe', 'link', 'meta', 'script', 'style']
+const IGNORED_ATTRS = ['style']
+
+export function sanitizeNode (node) {
+  return inflateNode(deflateNode(node))
+}
+
+export function deflateNode (node) {
+  let {nodeName, textContent} = node
+
+  if (FORBIDDEN_NODES.includes(nodeName.toLowerCase())) {
+    throw new Error(`Commands are not allowed to return ${nodeName} elements`)
+  }
+
+  let attributes = []
+  let childNodes = []
+
+  for (let child of node.childNodes) {
+    childNodes.push(deflateNode(child))
+  }
+
+  if (node.attributes) {
+    for (let i = 0; i < node.attributes.length; i++) {
+      let {name, value} = node.attributes[i]
+      if (IGNORED_ATTRS.includes(name.toLowerCase())) {
+        continue
+      }
+      attributes.push({name, value})
+    }
+  }
+
+  return {nodeName, textContent, attributes, childNodes}
+}
+
+export function inflateNode (tree) {
+  if (tree.nodeName === '#text') {
+    return document.createTextNode(tree.textContent)
+  }
+
+  let attr, child, el = document.createElement(tree.nodeName)
+
+  for (attr of tree.attributes) {
+    el.setAttribute(attr.name, attr.value)
+  }
+  for (child of tree.childNodes) {
+    el.appendChild(inflateNode(child))
+  }
+  return el
+}

--- a/js/lib/iframe-dom-transport.js
+++ b/js/lib/iframe-dom-transport.js
@@ -1,5 +1,11 @@
-const FORBIDDEN_NODES = ['iframe', 'link', 'meta', 'script', 'style']
 const IGNORED_ATTRS = ['style']
+const FORBIDDEN_NODES = [
+  'html', 'head', 'body', 'base',
+  'link', 'meta', 'script', 'style',
+  'iframe', 'embed', 'object', 'canvas',
+  'form', 'input', 'datalist', 'textarea',
+  'select', 'option', 'optgroup', 'button'
+]
 
 export function sanitizeNode (node) {
   return inflateNode(deflateNode(node))

--- a/js/lib/iframe-shim-dat-archive.js
+++ b/js/lib/iframe-shim-dat-archive.js
@@ -1,15 +1,27 @@
+const STATIC = /^static\:/
+
 export function shimDatArchiveGlobal () {
   window.DatArchive = DatArchiveShim
 }
 
-export function handleDatArchiveRequests () {
+export function handleDatArchiveRequests (allow = () => true) {
   window.addEventListener('message', async function ({data, source}) {
     if (data.type !== 'archive:req') return
-    let dat = new DatArchive(data.url)
-    let fn = dat[data.method].bind(dat)
+
+    if (!allow(data.url, data.method)) {
+      throw new Error('DatArchive access refused')
+    }
+    let method
+
+    if (STATIC.test(data.method)) {
+      method = DatArchive[data.method.replace(STATIC, '')]
+    } else {
+      let dat = new DatArchive(data.url)
+      method = dat[data.method].bind(dat)
+    }
 
     try {
-      let content = await fn(...data.args)
+      let content = await method(...data.args)
       respond({type: 'archive:res', content})
     } catch (err) {
       let {name, message, stack} = err
@@ -28,25 +40,106 @@ export function handleDatArchiveRequests () {
  * Shim interface
  */
 class DatArchiveShim {
+  static async load (...args) {
+    let res = await request({method: 'static:load', args})
+    return new this(res.url)
+  }
+
+  static async create (...args) {
+    let res = await request({method: 'static:create', args})
+    return new this(res.url)
+  }
+
+  static async fork (...args) {
+    let res = await request({method: 'static:fork', args})
+    return new this(res.url)
+  }
+
+  static async unlink (...args) {
+    return request({method: 'static:unlink', args})
+  }
+
+  static async selectArchive (...args) {
+    let res = await request({method: 'static:selectArchive', args})
+    return new this(res.url)
+  }
+
+  static async resolveName (...args) {
+    return request({method: 'static:resolveName', args})
+  }
+
   constructor (url) {
     this.url = url
   }
 
-  async readFile (...args) {
-    return request({type: 'archive:req', method: 'readFile', url: this.url, args})
+  async getInfo (...args) {
+    return request({method: 'getInfo', url: this.url, args})
+  }
+
+  async configure (...args) {
+    return request({method: 'configure', url: this.url, args})
   }
 
   async stat (...args) {
-    let stat = await request({type: 'archive:req', method: 'stat', url: this.url, args})
+    let stat = await request({method: 'stat', url: this.url, args})
     stat.isDirectory = () => stat.mode === 16877
     stat.isFile = () => stat.mode === 33188
     return stat
+  }
+
+  async readFile (...args) {
+    return request({method: 'readFile', url: this.url, args})
+  }
+
+  async readdir (...args) {
+    return request({method: 'readdir', url: this.url, args})
+  }
+
+  async writeFile (...args) {
+    return request({method: 'writeFile', url: this.url, args})
+  }
+
+  async mkdir (...args) {
+    return request({method: 'mkdir', url: this.url, args})
+  }
+
+  async unlink (...args) {
+    return request({method: 'unlink', url: this.url, args})
+  }
+
+  async rmdir (...args) {
+    return request({method: 'rmdir', url: this.url, args})
+  }
+
+  async copy (...args) {
+    return request({method: 'copy', url: this.url, args})
+  }
+
+  async rename (...args) {
+    return request({method: 'rename', url: this.url, args})
+  }
+
+  async history (...args) {
+    return request({method: 'history', url: this.url, args})
+  }
+
+  checkout (version) {
+    let urlp = new URL(this.url)
+    let base = urlp.hostname.split('+')[0]
+    this.url = `dat://${base}+${version}`
+    return this
+  }
+
+  async download (...args) {
+    return request({method: 'download', url: this.url, args})
   }
 }
 
 function request (params) {
   return new Promise(function (resolve, reject) {
     params.token = Math.random()
+    params.type = 'archive:req'
+
     window.addEventListener('message', listen)
     window.top.postMessage(params, window.location.origin)
 

--- a/js/lib/iframe-shim-dat-archive.js
+++ b/js/lib/iframe-shim-dat-archive.js
@@ -1,0 +1,63 @@
+export function shimDatArchiveGlobal () {
+  window.DatArchive = DatArchiveShim
+}
+
+export function handleDatArchiveRequests () {
+  window.addEventListener('message', async function ({data, source}) {
+    if (data.type !== 'archive:req') return
+    let dat = new DatArchive(data.url)
+    let fn = dat[data.method].bind(dat)
+
+    try {
+      let content = await fn(...data.args)
+      respond({type: 'archive:res', content})
+    } catch (err) {
+      let {name, message, stack} = err
+      let content = {name, message, stack}
+      respond({type: 'archive:err', content})
+    }
+
+    function respond (msg) {
+      msg.token = data.token
+      source.postMessage(msg, '*')
+    }
+  })
+}
+
+/**
+ * Shim interface
+ */
+class DatArchiveShim {
+  constructor (url) {
+    this.url = url
+  }
+
+  async readFile (...args) {
+    return request({type: 'archive:req', method: 'readFile', url: this.url, args})
+  }
+
+  async stat (...args) {
+    let stat = await request({type: 'archive:req', method: 'stat', url: this.url, args})
+    stat.isDirectory = () => stat.mode === 16877
+    stat.isFile = () => stat.mode === 33188
+    return stat
+  }
+}
+
+function request (params) {
+  return new Promise(function (resolve, reject) {
+    params.token = Math.random()
+    window.addEventListener('message', listen)
+    window.top.postMessage(params, window.location.origin)
+
+    function listen ({data}) {
+      if (data.token !== params.token) return
+      window.removeEventListener('message', listen)
+      switch (data.type) {
+        case 'archive:err': return reject(data.content)
+        case 'archive:res': return resolve(data.content)
+        default: console.warn('Unknown data type: ' + data.type)
+      }
+    }
+  })
+}

--- a/js/sandbox.js
+++ b/js/sandbox.js
@@ -1,0 +1,51 @@
+import { shimDatArchiveGlobal } from '/js/lib/iframe-shim-dat-archive.js'
+import { deflateNode } from '/js/lib/iframe-dom-transport.js'
+import { joinPath } from '/vendor/beaker-app-stdlib/js/strings.js'
+
+if (typeof window.DatArchive === 'undefined') {
+  shimDatArchiveGlobal()
+}
+
+window.addEventListener('message', function receive ({data}) {
+  if (data.type !== 'prompt:eval') return
+  window.cwd = data.cwd
+  evaluate(data.cmd, data.args, data.token)
+})
+
+async function evaluate (cmd, args, token) {
+  try {
+    var mod = await load(cmd)
+    var fn = mod[args[1]] ? mod[args.shift()] : mod.default
+    var output = await fn(...args)
+
+    if (typeof output === 'undefined' || typeof output === 'string') {
+      output = pre(output || 'Ok.')
+    } else if (output.toHTML) {
+      output = output.toHTML()
+    } else if (!(output instanceof Element)) {
+      output = pre(JSON.stringify(output).replace(/^"|"$/g, ''))
+    }
+    send({type: 'prompt:res', output: deflateNode(output), token})
+  } catch (err) {
+    var error = {name: err.name, message: err.message, stack: err.stack}
+    send({type: 'prompt:err', error, token})
+  }
+}
+
+async function load (cmd) {
+  var path = joinPath(window.cwd.url, cmd)
+  if (!path.endsWith('.js')) {
+    path += '.js'
+  }
+  return import(path)
+}
+
+function pre (text) {
+  var el = document.createElement('pre')
+  el.innerText = text
+  return el
+}
+
+function send (data) {
+  window.parent.postMessage(data, window.location.origin)
+}

--- a/js/sandbox.js
+++ b/js/sandbox.js
@@ -8,15 +8,16 @@ if (typeof window.DatArchive === 'undefined') {
 
 window.addEventListener('message', function receive ({data}) {
   if (data.type !== 'prompt:eval') return
+  window.cmd = data.cmd
   window.cwd = data.cwd
-  evaluate(data.cmd, data.args, data.token)
+  evaluate(data.opts, data.args, data.token)
 })
 
-async function evaluate (cmd, args, token) {
+async function evaluate (opts, args, token) {
   try {
-    var mod = await load(cmd)
-    var fn = mod[args[1]] ? mod[args.shift()] : mod.default
-    var output = await fn(...args)
+    var module = await load(window.cmd)
+    var command = module[args[0]] ? module[args.shift()] : module.default
+    var output = await command(opts, ...args)
 
     if (typeof output === 'undefined' || typeof output === 'string') {
       output = pre(output || 'Ok.')

--- a/js/sandbox.js
+++ b/js/sandbox.js
@@ -33,11 +33,22 @@ async function evaluate (cmd, args, token) {
 }
 
 async function load (cmd) {
-  var path = joinPath(window.cwd.url, cmd)
-  if (!path.endsWith('.js')) {
-    path += '.js'
+  var url
+
+  try {
+    url = new URL(cmd)
+  } catch (err) {
+    url = new URL(joinPath(window.cwd.url, cmd))
   }
-  return import(path)
+  if (!url.pathname.endsWith('.js')) {
+    url.pathname += '.js'
+  }
+
+  try {
+    return await import(url)
+  } catch (err) {
+    throw new Error('Command not found: ' + cmd)
+  }
 }
 
 function pre (text) {

--- a/js/sandbox.js
+++ b/js/sandbox.js
@@ -52,9 +52,7 @@ async function load (cmd) {
 }
 
 function pre (text) {
-  var el = document.createElement('pre')
-  el.innerText = text
-  return el
+  return document.createTextNode(text)
 }
 
 function send (data) {

--- a/js/views/terminal.js
+++ b/js/views/terminal.js
@@ -233,13 +233,15 @@ class WebTerm extends LitElement {
       var token = Math.random()
 
       // Refresh iframe before evaluation for clean execution environment
-      this.sandbox.addEventListener('load', send.bind(this))
-      this.sandbox.src = this.sandbox.src
+      var {cwd, sandbox} = this
+      sandbox.addEventListener('load', send)
+      sandbox.src = this.sandbox.src
 
       function send () {
+        var opts = args.shift()
         window.addEventListener('message', listen)
-        window.frames[0].postMessage({type: 'prompt:eval', cwd: this.cwd, cmd, args, token}, '*')
-        this.sandbox.removeEventListener('load', send)
+        window.frames[0].postMessage({type: 'prompt:eval', cwd, cmd, opts, args, token}, '*')
+        sandbox.removeEventListener('load', send)
       }
 
       function listen ({data}) {

--- a/js/views/terminal.js
+++ b/js/views/terminal.js
@@ -218,9 +218,11 @@ class WebTerm extends LitElement {
 
     if (typeof output === 'undefined') {
       return 'Ok.'
+    } else if (typeof output === 'string') {
+      return output
     } else if (output.toHTML) {
       return output.toHTML()
-    } else if (typeof output !== 'string' && !(output instanceof TemplateResult)) {
+    } else if (!(output instanceof TemplateResult)) {
       return JSON.stringify(output).replace(/^"|"$/g, '')
     }
   }

--- a/sandbox.html
+++ b/sandbox.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>command execution sandbox</title>
+    <script type="module" src="/js/sandbox.js"></script>
+  </head>
+</html>


### PR DESCRIPTION
As discussed in https://github.com/dfurl/dterm/issues/12, this PR will port my work on dterm's execution environment to the Beaker sidebar terminal. I'm opening the PR early, so that you can already have a look, but there's still some work to do before it can be merged:

- [x] Implement the missing methods on the `DatArchive` shim
- [x] Support fully-qualified script URLs
- [x] ~~Resolve saved scripts from user directory~~ (Out of scope.)
- [x] Add more meaningful error message when command can't be resolved